### PR TITLE
Optimize deobfuscator performance

### DIFF
--- a/deobfuscator/src/main/java/com/badoo/hprof/deobfuscator/DataCollectionProcessor.java
+++ b/deobfuscator/src/main/java/com/badoo/hprof/deobfuscator/DataCollectionProcessor.java
@@ -184,9 +184,7 @@ public class DataCollectionProcessor extends DiscardProcessor {
 
         long stringIdLong = lastStringId.toLong();
         stringIdLong++;
-        System.out.println("ID_CURR=" + lastStringId);
         lastStringId = new ID(stringIdLong);
-        System.out.println("ID_Next="+lastStringId);
         return lastStringId;
     }
 

--- a/deobfuscator/src/main/java/com/badoo/hprof/deobfuscator/HprofDeobfuscator.java
+++ b/deobfuscator/src/main/java/com/badoo/hprof/deobfuscator/HprofDeobfuscator.java
@@ -61,7 +61,6 @@ public class HprofDeobfuscator {
             }
             hprofStrings = dataCollectionProcessor.getStrings();
 
-            System.out.println(hprofStrings);
 
             // Deobfuscate all class names first since they are needed when processing fields and methods
             for (ClassDefinition cls : dataCollectionProcessor.getClasses().values()) {

--- a/deobfuscator/src/main/java/com/badoo/hprof/deobfuscator/StringUpdateProcessor.java
+++ b/deobfuscator/src/main/java/com/badoo/hprof/deobfuscator/StringUpdateProcessor.java
@@ -71,7 +71,6 @@ public class StringUpdateProcessor extends CopyProcessor {
     @Override
     public void onRecord(int tag, int timestamp, int length, @Nonnull HprofReader reader) throws IOException {
 
-        System.out.println(Tag.tagToString(tag));
 
         if (tag == Tag.STRING) {
             skip(reader.getInputStream(), length); // Discard all the original strings


### PR DESCRIPTION
 Delete debug info (println) to avoid io, stdout buffer blocking
