### PR TITLE
Fix deobfuscation of array types

### DIFF
--- a/deobfuscator/src/main/java/com/badoo/hprof/deobfuscator/Mapping.java
+++ b/deobfuscator/src/main/java/com/badoo/hprof/deobfuscator/Mapping.java
@@ -127,7 +127,31 @@ class Mapping implements MappingProcessor {
     private Map<String, Map<MethodInfoKey,MethodInfo>> methodMapping = new HashMap<String, Map<MethodInfoKey, MethodInfo>>();
 
     public String getClassName(String obfuscatedName) {
+        if (obfuscatedName.endsWith("[]")) {
+          return getArrayClassName(obfuscatedName);
+        }
         return classNameMapping.get(obfuscatedName);
+    }
+
+    private String getArrayClassName(final String obfuscatedName) {
+        String componentName = getArrayComponentName(obfuscatedName);
+        String suffix = obfuscatedName.substring(componentName.length());
+        String deobfuscatedComponentName = classNameMapping.get(componentName);
+        if (deobfuscatedComponentName == null) {
+          return deobfuscatedComponentName;
+        }
+
+        return deobfuscatedComponentName.concat(suffix);
+    }
+
+    private String getArrayComponentName(final String className) {
+        int endIndex = className.length();
+        while (endIndex >= 0
+            && (className.charAt(endIndex - 2) == '[')
+            && (className.charAt(endIndex - 1) == ']')) {
+          endIndex -= 2;
+        }
+        return className.substring(0, endIndex);
     }
 
     public Map<String, FieldInfo> getFieldMappingsForClass(String className) {


### PR DESCRIPTION
This patch should fix issue #10 that I filed a few moments ago. 

Test plan:
 1. Build sample app that contains a simple activity with array member.
 2. Run the app and dump a heap profile.
 3. Deobfuscate the heap profile using deobfuscator.jar
 4. Open the heap profile in Android Studio.
 5. Confirm that the heap profile shows the array member variable with its properly deobfuscated type.